### PR TITLE
reduce flickering in static ctrls

### DIFF
--- a/src/msw/statbmp.cpp
+++ b/src/msw/statbmp.cpp
@@ -135,6 +135,9 @@ bool wxStaticBitmap::Create(wxWindow *parent,
     }
 #endif // !__WXWINCE__
 
+    // reduce flickering
+    Bind(wxEVT_ERASE_BACKGROUND, [](wxEraseEvent&){});
+
     return true;
 }
 

--- a/src/msw/stattext.cpp
+++ b/src/msw/stattext.cpp
@@ -52,6 +52,9 @@ bool wxStaticText::Create(wxWindow *parent,
     InvalidateBestSize();
     SetInitialSize(size);
 
+    // reduce flickering
+    Bind(wxEVT_ERASE_BACKGROUND, [](wxEraseEvent&){});
+
     // NOTE: if the label contains ampersand characters which are interpreted as
     //       accelerators, they will be rendered (at least on WinXP) only if the
     //       static text is placed inside a window class which correctly handles


### PR DESCRIPTION
empty erase event handler
- see [Flicker-Free Drawing](http://wiki.wxwidgets.org/Flicker-Free_Drawing) on wxWiki
