### PR TITLE
resolve conflicting declarations

### DIFF
--- a/include/wx/unix/glx11.h
+++ b/include/wx/unix/glx11.h
@@ -10,7 +10,17 @@
 #ifndef _WX_UNIX_GLX11_H_
 #define _WX_UNIX_GLX11_H_
 
+#if defined __sun && ((__GNUC__ == 4) && (__GNUC_MINOR__ < 6))
+// these defines are used to resolve conflict on Solaris 10 gcc 4.5.3
+// between /usr/openwin/include/GL/glext.h and /usr/include/sys/int_types.h
+# define uint64_t uint64_t_hack
+# define int64_t int64_t_hack
+# include <GL/glx.h>
+# undef uint64_t
+# undef int64_t
+#else
 #include <GL/glx.h>
+#endif
 
 // ----------------------------------------------------------------------------
 // wxGLContext


### PR DESCRIPTION
Conflicting declarations of `uint64_t` and `int64_t` on Solaris 10 with self-built gcc 4.5.3 (problem doesn't exist on Solaris 10 with [package-based](http://mirror.opencsw.org/opencsw/stable/i386/5.10/) gcc 4.6.3).

Idea from [macports](http://trac.macports.org/ticket/38168) and [opencv](https://github.com/Itseez/opencv/commit/33c26a93c6d97013b14e7dd080a347e242ef7f37)

Compile errors:

```
In file included from /usr/openwin/include/GL/glx.h:38:0,
                 from /home/smanders/src/externpro/_bldwx/xpbase/Source/wx30/include/wx/unix/glx11.h:13,
                 from /home/smanders/src/externpro/_bldwx/xpbase/Source/wx30/include/wx/gtk/glcanvas.h:14,
                 from /home/smanders/src/externpro/_bldwx/xpbase/Source/wx30/include/wx/glcanvas.h:192,
                 from /home/smanders/src/externpro/_bldwx/xpbase/Source/wx30/src/common/glcmn.cpp:31:
/usr/openwin/include/X11/Xlib.h:38:0: warning: ignoring #pragma ident 
In file included from /usr/openwin/include/GL/glx.h:39:0,
                 from /home/smanders/src/externpro/_bldwx/xpbase/Source/wx30/include/wx/unix/glx11.h:13,
                 from /home/smanders/src/externpro/_bldwx/xpbase/Source/wx30/include/wx/gtk/glcanvas.h:14,
                 from /home/smanders/src/externpro/_bldwx/xpbase/Source/wx30/include/wx/glcanvas.h:192,
                 from /home/smanders/src/externpro/_bldwx/xpbase/Source/wx30/src/common/glcmn.cpp:31:
/usr/openwin/include/X11/Xutil.h:56:0: warning: ignoring #pragma ident 
In file included from /usr/openwin/include/GL/gl.h:2149:0,
                 from /usr/openwin/include/GL/glx.h:45,
                 from /home/smanders/src/externpro/_bldwx/xpbase/Source/wx30/include/wx/unix/glx11.h:13,
                 from /home/smanders/src/externpro/_bldwx/xpbase/Source/wx30/include/wx/gtk/glcanvas.h:14,
                 from /home/smanders/src/externpro/_bldwx/xpbase/Source/wx30/include/wx/glcanvas.h:192,
                 from /home/smanders/src/externpro/_bldwx/xpbase/Source/wx30/src/common/glcmn.cpp:31:
/usr/openwin/include/GL/glext.h:3175:23: error: conflicting declaration ‘typedef long long int int64_t’
/usr/include/sys/int_types.h:64:16: error: ‘int64_t’ has a previous declaration as ‘typedef long int int64_t’
/usr/openwin/include/GL/glext.h:3176:32: error: conflicting declaration ‘typedef long long unsigned int uint64_t’
/usr/include/sys/int_types.h:76:24: error: ‘uint64_t’ has a previous declaration as ‘typedef long unsigned int uint64_t’
gmake[3]: *** [gllib_glcmn.o] Error 1
```
