### PR TITLE
paint background

### DIFF
--- a/src/generic/statbmpg.cpp
+++ b/src/generic/statbmpg.cpp
@@ -15,6 +15,8 @@
     #include "wx/dcclient.h"
 #endif
 
+#include "wx/dcbuffer.h"
+#include "wx/graphics.h"
 #include "wx/generic/statbmpg.h"
 
 bool wxGenericStaticBitmap::Create(wxWindow *parent, wxWindowID id,
@@ -25,6 +27,7 @@ bool wxGenericStaticBitmap::Create(wxWindow *parent, wxWindowID id,
     if (! wxControl::Create(parent, id, pos, size, style,
                             wxDefaultValidator, name))
         return false;
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
     SetBitmap(bitmap);
     Connect(wxEVT_PAINT, wxPaintEventHandler(wxGenericStaticBitmap::OnPaint));
     // reduce flickering
@@ -34,9 +37,15 @@ bool wxGenericStaticBitmap::Create(wxWindow *parent, wxWindowID id,
 
 void wxGenericStaticBitmap::OnPaint(wxPaintEvent& WXUNUSED(event))
 {
-    wxPaintDC dc(this);
+    wxAutoBufferedPaintDC dc(this);
+    wxScopedPtr<wxGraphicsContext> gc(wxGraphicsContext::Create(dc));
+    auto bgClr = GetParent()->GetBackgroundColour();
+    if (UseBgCol())
+        bgClr = GetBackgroundColour();
+    dc.SetBackground(wxBrush(bgClr));
+    dc.Clear();
     if (m_bitmap.IsOk())
-        dc.DrawBitmap(m_bitmap, 0, 0, true);
+        gc->DrawBitmap(m_bitmap, 0, 0, m_bitmap.GetWidth(), m_bitmap.GetHeight());
 }
 
 // under OSX_cocoa is a define, avoid duplicate info

--- a/src/generic/stattextg.cpp
+++ b/src/generic/stattextg.cpp
@@ -21,6 +21,7 @@
     #include "wx/validate.h"
 #endif
 
+#include "wx/dcbuffer.h"
 #include "wx/generic/stattextg.h"
 
 #if wxUSE_MARKUP
@@ -42,6 +43,7 @@ bool wxGenericStaticText::Create(wxWindow *parent,
                             wxDefaultValidator, name) )
         return false;
 
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
     SetLabel(label);
     SetInitialSize(size);
     Connect(wxEVT_PAINT, wxPaintEventHandler(wxGenericStaticText::OnPaint));
@@ -69,7 +71,13 @@ void wxGenericStaticText::DoDrawLabel(wxDC& dc, const wxRect& rect)
 
 void wxGenericStaticText::OnPaint(wxPaintEvent& WXUNUSED(event))
 {
-    wxPaintDC dc(this);
+    wxAutoBufferedPaintDC dc(this);
+
+    auto bgClr = GetParent()->GetBackgroundColour();
+    if ( UseBgCol() )
+        bgClr = GetBackgroundColour();
+    dc.SetBackground(wxBrush(bgClr));
+    dc.Clear();
 
     wxRect rect = GetClientRect();
     if ( IsEnabled() )


### PR DESCRIPTION
- we introduced an empty wxEVT_ERASE_BACKGROUND event handler (to reduce flickering)
- now we need to paint the background (drawing artifacts seen maximizing app on msw)
